### PR TITLE
compare instance against parserbase

### DIFF
--- a/src/subtitle-stream.js
+++ b/src/subtitle-stream.js
@@ -4,7 +4,7 @@ export class SubtitleStream extends SubtitleParserBase {
   constructor (prevInstance) {
     super()
 
-    if (prevInstance instanceof SubtitleStream) {
+    if (prevInstance instanceof SubtitleParserBase) {
       prevInstance.once('drain', () => prevInstance.end())
 
       // copy previous metadata


### PR DESCRIPTION
This allows to create a new SubtitleStream instance which inherits SubtitleParser's data.