### PR TITLE
fix: performance on node

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ parser.once('tracks', (tracks) => console.log(tracks))
 parser.on('subtitle', (subtitle, trackNumber) =>
   console.log('Track ' + trackNumber + ':', subtitle))
 
+parser.on('chapters', chapters => console.log(chapters))
+
 fs.createReadStream('Sintel.2010.720p.mkv').pipe(parser)
 ```
 
@@ -61,6 +63,17 @@ See [examples](https://github.com/mathiasvr/matroska-subtitles/tree/master/examp
   time: 107250,  // ms
   duration: 1970 // ms
 }
+```
+
+### `chapters` event response format
+
+```js
+[
+  { start: 0, /*ms*/ end: 89900, /*ms*/ text: 'OP', language: 'eng' },
+  { start: 89900, end: 634860, text: 'Part A', language: 'eng' },
+  { start: 634860, end: 1279840, text: 'Part B', language: 'eng' },
+  { start: 1279840, end: 1369877, text: 'ED', language: 'eng' }
+]
 ```
 
 ## attached files

--- a/src/subtitle-parser-base.js
+++ b/src/subtitle-parser-base.js
@@ -1,16 +1,18 @@
-import { Transform } from 'readable-stream'
+import { PassThrough } from 'readable-stream'
 import { EbmlStreamDecoder, EbmlTagId } from 'ebml-stream'
 import { inflateSync } from 'zlib'
 
 const SSA_TYPES = new Set(['ssa', 'ass'])
 const SSA_KEYS = ['readOrder', 'layer', 'style', 'name', 'marginL', 'marginR', 'marginV', 'effect', 'text']
 
-function getData (chunk, id) {
-  const el = chunk.Children.find(c => c.id === id)
-  return el ? el.data : undefined
+function getChild (chunk, tag) {
+  return chunk?.Children.find(({ id }) => id === tag)
+}
+function getData (chunk, tag) {
+  return getChild(chunk, tag)?.data
 }
 
-export class SubtitleParserBase extends Transform {
+export class SubtitleParserBase extends PassThrough {
   constructor () {
     super()
 
@@ -24,105 +26,137 @@ export class SubtitleParserBase extends Transform {
         EbmlTagId.TimecodeScale,
         EbmlTagId.Tracks,
         EbmlTagId.BlockGroup,
-        EbmlTagId.AttachedFile
+        EbmlTagId.AttachedFile,
+        EbmlTagId.Chapters,
+        EbmlTagId.Duration
       ]
     })
 
-    this.decoder.on('data', this.parseEbmlSubtitles.bind(this))
+    const tagMap = {
+      // Segment Information
+      [EbmlTagId.TimecodeScale]: ({ data }) => {
+        this.timecodeScale = data / 1000000
+      },
+      // Assumption: This is a Cluster `Timecode`
+      [EbmlTagId.Timecode]: ({ data }) => {
+        this._currentClusterTimecode = data
+      },
+      // Parse attached files, mainly to allow extracting subtitle font files.
+      [EbmlTagId.AttachedFile]: chunk => {
+        this.emit('file', {
+          filename: getData(chunk, EbmlTagId.FileName),
+          mimetype: getData(chunk, EbmlTagId.FileMimeType),
+          data: getData(chunk, EbmlTagId.FileData)
+        })
+      },
+      // Duration for chapters which don't specify an end position
+      [EbmlTagId.Duration]: ({ data }) => {
+        this.duration = data
+      },
+      [EbmlTagId.Tracks]: this.handleTracks.bind(this),
+      [EbmlTagId.BlockGroup]: this.handleBlockGroup.bind(this),
+      [EbmlTagId.Chapters]: this.handleChapters.bind(this)
+    }
+    this.decoder.on('data', chunk => {
+      tagMap[chunk.id]?.(chunk)
+    })
   }
 
-  parseEbmlSubtitles (chunk) {
-    // Segment Information
-    if (chunk.id === EbmlTagId.TimecodeScale) {
-      this.timecodeScale = chunk.data / 1000000
-    }
+  handleTracks (chunk) {
+    for (const entry of chunk.Children.filter(c => c.id === EbmlTagId.TrackEntry)) {
+      // Skip non subtitle tracks
+      if (getData(entry, EbmlTagId.TrackType) !== 0x11) continue
 
-    // Assumption: This is a Cluster `Timecode`
-    if (chunk.id === EbmlTagId.Timecode) {
-      this._currentClusterTimecode = chunk.data
-    }
-
-    if (chunk.id === EbmlTagId.Tracks) {
-      for (const entry of chunk.Children.filter(c => c.id === EbmlTagId.TrackEntry)) {
-        // Skip non subtitle tracks
-        if (getData(entry, EbmlTagId.TrackType) !== 0x11) continue
-
-        const codecID = getData(entry, EbmlTagId.CodecID) || ''
-        if (codecID.startsWith('S_TEXT')) {
-          const track = {
-            number: getData(entry, EbmlTagId.TrackNumber),
-            language: getData(entry, EbmlTagId.Language),
-            type: codecID.substring(7).toLowerCase()
-          }
-
-          const name = getData(entry, EbmlTagId.Name)
-          if (name) {
-            track.name = name
-          }
-
-          const header = getData(entry, EbmlTagId.CodecPrivate)
-          if (header) {
-            track.header = header.toString()
-          }
-
-          // TODO: Assume zlib deflate compression
-          const compressed = entry.Children.find(c =>
-            c.id === EbmlTagId.ContentEncodings &&
-            c.Children.find(cc =>
-              cc.id === EbmlTagId.ContentEncoding &&
-              cc.Children.find(ccc => ccc.id === EbmlTagId.ContentCompression)))
-
-          if (compressed) {
-            track._compressed = true
-          }
-
-          this.subtitleTracks.set(track.number, track)
-        }
-      }
-
-      this.emit('tracks', Array.from(this.subtitleTracks.values()))
-    }
-
-    if (chunk.id === EbmlTagId.BlockGroup) {
-      const block = chunk.Children.find(c => c.id === EbmlTagId.Block)
-
-      if (block && this.subtitleTracks.has(block.track)) {
-        const blockDuration = getData(chunk, EbmlTagId.BlockDuration)
-        const track = this.subtitleTracks.get(block.track)
-
-        const payload = track._compressed
-          ? inflateSync(Buffer.from(block.payload))
-          : block.payload
-
-        const subtitle = {
-          text: payload.toString('utf8'),
-          time: (block.value + this._currentClusterTimecode) * this.timecodeScale,
-          duration: blockDuration * this.timecodeScale
+      const codecID = getData(entry, EbmlTagId.CodecID) || ''
+      if (codecID.startsWith('S_TEXT')) {
+        const track = {
+          number: getData(entry, EbmlTagId.TrackNumber),
+          language: getData(entry, EbmlTagId.Language),
+          type: codecID.substring(7).toLowerCase()
         }
 
-        if (SSA_TYPES.has(track.type)) {
-          // extract SSA/ASS keys
-          const values = subtitle.text.split(',')
+        const name = getData(entry, EbmlTagId.Name)
+        if (name) track.name = name
 
-          // ignore read-order, and skip layer if ssa
-          for (let i = track.type === 'ssa' ? 2 : 1; i < 8; i++) {
-            subtitle[SSA_KEYS[i]] = values[i]
-          }
+        const header = getData(entry, EbmlTagId.CodecPrivate)
+        if (header) track.header = header.toString()
 
-          subtitle.text = values.slice(8).join(',')
-        }
+        // TODO: Assume zlib deflate compression
+        const compressed = entry.Children.find(c =>
+          c.id === EbmlTagId.ContentEncodings &&
+          c.Children.find(cc =>
+            cc.id === EbmlTagId.ContentEncoding &&
+            getChild(cc, EbmlTagId.ContentCompression)
+          )
+        )
 
-        this.emit('subtitle', subtitle, block.track)
+        if (compressed) track._compressed = true
+
+        this.subtitleTracks.set(track.number, track)
       }
     }
 
-    // Parse attached files, mainly to allow extracting subtitle font files.
-    if (chunk.id === EbmlTagId.AttachedFile) {
-      this.emit('file', {
-        filename: getData(chunk, EbmlTagId.FileName),
-        mimetype: getData(chunk, EbmlTagId.FileMimeType),
-        data: getData(chunk, EbmlTagId.FileData)
+    this.emit('tracks', [...this.subtitleTracks.values()])
+  }
+
+  handleBlockGroup (chunk) {
+    const block = getChild(chunk, EbmlTagId.Block)
+
+    if (block && this.subtitleTracks.has(block.track)) {
+      const blockDuration = getData(chunk, EbmlTagId.BlockDuration)
+      const track = this.subtitleTracks.get(block.track)
+
+      const payload = track._compressed
+        ? inflateSync(Buffer.from(block.payload))
+        : block.payload
+
+      const subtitle = {
+        text: payload.toString('utf8'),
+        time: (block.value + this._currentClusterTimecode) * this.timecodeScale,
+        duration: blockDuration * this.timecodeScale
+      }
+
+      if (SSA_TYPES.has(track.type)) {
+        // extract SSA/ASS keys
+        const values = subtitle.text.split(',')
+
+        // ignore read-order, and skip layer if ssa
+        for (let i = track.type === 'ssa' ? 2 : 1; i < 8; i++) {
+          subtitle[SSA_KEYS[i]] = values[i]
+        }
+
+        subtitle.text = values.slice(8).join(',')
+      }
+
+      this.emit('subtitle', subtitle, block.track)
+    }
+  }
+
+  handleChapters ({ Children }) {
+    const editions = Children.filter(c => c.id === EbmlTagId.EditionEntry)
+    // https://www.matroska.org/technical/chapters.html#default-edition
+    // finds first default edition, or first entry
+    const defaultEdition = editions.find(c => {
+      return c.Children.some(cc => {
+        return cc.id === EbmlTagId.EditionFlagDefault && Boolean(cc.data)
       })
+    }) || editions[0]
+
+    // exclude hidden atoms
+    const atoms = defaultEdition.Children.filter(c => c.id === EbmlTagId.ChapterAtom && !getData(c, EbmlTagId.ChapterFlagHidden))
+    const chapters = []
+    for (let i = atoms.length - 1; i >= 0; --i) {
+      const start = getData(atoms[i], EbmlTagId.ChapterTimeStart) / this.timecodeScale / 1000000
+      const end = (getData(atoms[i], EbmlTagId.ChapterTimeEnd) / this.timecodeScale / 1000000) || chapters[i + 1]?.start || this.duration
+      const disp = getChild(atoms[i], EbmlTagId.ChapterDisplay)
+
+      chapters[i] = {
+        start,
+        end,
+        text: getData(disp, EbmlTagId.ChapString),
+        language: getData(disp, EbmlTagId.ChapLanguage)
+      }
     }
+    this.emit('chapters', chapters)
   }
 }

--- a/src/subtitle-stream.js
+++ b/src/subtitle-stream.js
@@ -1,4 +1,5 @@
 import { SubtitleParserBase } from './subtitle-parser-base'
+import { EbmlTagId } from 'ebml-stream'
 
 export class SubtitleStream extends SubtitleParserBase {
   constructor (prevInstance) {
@@ -14,31 +15,31 @@ export class SubtitleStream extends SubtitleParserBase {
       // may not be at ebml tag offset
       this.unstable = true
     }
+    this.on('data', this._ondata.bind(this))
   }
 
   // passthrough stream: data is intercepted but not transformed
-  _transform (chunk, _, callback) {
+  _ondata (chunk) {
     if (this.unstable) {
       // the ebml decoder expects to see a tag, so we won't use it until we find a cluster
       for (let i = 0; i < chunk.length - 12; i++) {
-        // cluster id
+        // cluster id 0x1F43B675
+        // https://matroska.org/technical/elements.html#LevelCluster
         if (chunk[i] === 0x1f && chunk[i + 1] === 0x43 && chunk[i + 2] === 0xb6 && chunk[i + 3] === 0x75) {
           // length of cluster size tag
           const len = 8 - Math.floor(Math.log2(chunk[i + 4]))
-          // first tag in cluster is cluster timecode
-          if (chunk[i + 4 + len] === 0xe7) {
+          // first tag in cluster is a valid EbmlTag
+          if (EbmlTagId[chunk[i + 4 + len]]) {
             // okay this is probably a cluster
             this.unstable = false
             this.decoderWrite(chunk.slice(i))
-            break
+            return
           }
         }
       }
     } else {
       this.decoderWrite(chunk)
     }
-
-    callback(null, chunk)
   }
 
   decoderWrite (chunk) {
@@ -46,7 +47,7 @@ export class SubtitleStream extends SubtitleParserBase {
     try {
       this.decoder.write(chunk)
     } catch (err) {
-      console.warn('[matroska-subtitles] EBML stream decoding error')
+      console.warn('[matroska-subtitles] EBML stream decoding error', err)
     }
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -47,6 +47,11 @@ function testBasic () {
     { number: 7, language: 'und', type: 'utf8' }
   ]))
 
+  parser.once('chapters', chapters => {
+    // test files don't have chapters :/
+    deepStrictEqual(chapters, [])
+  })
+
   const subtitles = {}
 
   parser.on('subtitle', (subtitle, trackNumber) => {


### PR DESCRIPTION
This PR fixes a performance issue when using Transform streams, which caused some video players to get stalled, this was because the transform would wait for the parser to finish parsing before it could continue, we don't care about that as we don't mutate data, just parse it

Additionally it fixes an issue where subtitlestream would stop parsing it metadata wasn't fully according to spec, for example some encoders would embed CR32 as the first tag in the cluster, not the timescale

Adds chapters